### PR TITLE
fix: update license field to reflect dual MIT/Apache-2.0 licensing

### DIFF
--- a/frozenkrill-core/Cargo.toml
+++ b/frozenkrill-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "frozenkrill-core"
 version = "0.0.0"
 edition = "2021"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 alkali = "0.3"


### PR DESCRIPTION
## Summary
Updates the `license` field in frozenkrill-core/Cargo.toml from `"MIT"` to `"MIT OR Apache-2.0"`.

## Motivation
The repository contains both LICENSE-MIT and LICENSE-APACHE files, indicating dual licensing, but the Cargo.toml only declared MIT. This mismatch causes confusion and doesn't accurately represent the licensing terms.

## Impact
- Properly reflects the dual licensing structure already present in the repository
- Provides users clarity on license options
- Improves metadata accuracy for cargo and dependency analysis tools