### PR TITLE
chore(nix): use nixpkgs rust, keep musl cross on x86_64

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,45 +34,10 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1756348497,
-        "narHash": "sha256-xJp3VnoYh4kpsaKFO/7SsGbwOz7pI1ZmjbqpXEuR2cw=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "0adf92c70d23fb4f703aea5d3ebb51ac65994f7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,38 +1,40 @@
 {
-  description = "Rust project with musl target";
+  description = "Rust project with musl target on x86_64, host toolchain elsewhere";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay.url = "github:oxalica/rust-overlay";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ (import rust-overlay) ];
-        };
-        
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" "rust-analyzer" ];
-          targets = [ "x86_64-unknown-linux-musl" ];
-        };
+        pkgs = import nixpkgs { inherit system; };
+        isX86_64Linux = system == "x86_64-linux";
+        muslCC = pkgs.pkgsStatic.stdenv.cc;
       in
       {
-        devShells.default = pkgs.mkShell {
+        devShells.default = pkgs.mkShell ({
           packages = with pkgs; [
             bashInteractive
-            rustToolchain
+            rustc
+            cargo
+            rustfmt
+            clippy
+            rust-analyzer
             pkg-config
-            pkgsStatic.stdenv.cc
             cargo-edit
-          ];
+          ] ++ pkgs.lib.optionals isX86_64Linux [ muslCC ];
 
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
-          CC_x86_64_unknown_linux_musl = "${pkgs.pkgsStatic.stdenv.cc}/bin/${pkgs.pkgsStatic.stdenv.cc.targetPrefix}cc";
-        };
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+
+          shellHook = pkgs.lib.optionalString (!isX86_64Linux) ''
+            export CARGO_BUILD_TARGET="$(rustc -vV | sed -n 's/^host: //p')"
+          '';
+        } // pkgs.lib.optionalAttrs isX86_64Linux {
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${muslCC}/bin/${muslCC.targetPrefix}cc";
+          CC_x86_64_unknown_linux_musl = "${muslCC}/bin/${muslCC.targetPrefix}cc";
+        });
       }
     );
 }


### PR DESCRIPTION
## Summary
- Drop `rust-overlay`; use nixpkgs' Rust toolchain (substitutable from `cache.nixos.org`).
- Preserve the x86_64-linux musl cross-compile flow exactly as before (`pkgsStatic.stdenv.cc` + `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER` env vars).
- On other systems (aarch64-linux, *-darwin), default `CARGO_BUILD_TARGET` to the host triple so `nix develop` works without the repo's `.cargo/config.toml` musl pin getting in the way.

## Why
`rust-overlay` unpacks Rust toolchain tarballs inside Nix builders. Some Linux environments — notably Android via PRoot/Termux — can't reliably handle tar's `mkdir`-then-`chmod` sequence, which breaks `nix develop` with errors like `Cannot change mode to rwxr-xr-x: No such file or directory`. nixpkgs' Rust ships as pre-built substitutable outputs, avoiding the unpack step entirely.

## Test plan
- [x] `nix develop && cargo build --release` on aarch64-linux (PRoot/Android) — produces a working host binary
- [ ] `nix develop` on x86_64-linux still produces a musl-cross-compiled release
- [ ] CI passes on x86_64-linux (existing workflow already exercises `nix develop`)